### PR TITLE
Got it working on modern Python & wrote a bit of description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
 # slack-zotero
-Simple interface between Slack Webhooks and Zotero API
+
+Simple interface between a Zotero 'group' and a Slack-compatible webhook. 
+Zotero is an open-source reference manager, and the 'groups' allow you to
+collective add to a shared library of academic work. 
+This code then checks this library, and automatically injects messages this new
+literature into your group-chat (such as Slack or Zulip). 
+
+Effectively this enables low-friction 'journal-club' discussions to naturally
+arise, and for other group members to easily keep up to date with the latest
+exciting literature. 
+
+I think this works particularly well with Zulip due to it's entirely
+thread-based way of organising group chat, and easy ability to move these
+automatically generated threads from the 'bot' channel to where ether they make
+the most sense (project based, methods etc.)
+
+## Pictorial example
+
+A picture is probably the most useful explanation - this was generated
+automatically after adding a classic paper. 
+https://mobile.twitter.com/JarvistFrost/status/1300432993354502144
+
+## Getting started
+
+Hopefully fairly explanatory. Email / Tweet me if you get stuck.
+
+`zulip-zotero.sh` is just an expanded call signature of what was previously in
+the doc string of the python code. 
+The python code has been very slightly fixed up, and a Zulip-convenient new
+default of setting the thread-topic ('channel') to the title of the academic
+paper.
+
+You'd then need to setup some method of calling this regularly. (Such as with
+`cron` on an always-on server.) Currently I'm just running this in a loop with
+an hours sleep, in a tmux window on my office workstation. :)
+
+## Constructing the webhook URL for Zulip:
+
+(Lifted from the Zulip documentation.)
+
+Construct the URL for the Slack-compatible webhook bot using the bot's API key
+and the desired stream name:
+
+https://yourZulipDomain.zulipchat.com/api/v1/external/slack_incoming?api_key=abcdefgh&stream=stream%20name
+
+Modify the parameters of the URL above, where api_key is the API key of your
+Zulip bot, and stream is the URL-encoded stream name you want the notifications
+sent to. If you do not specify a stream, the bot will send notifications via
+PMs to the creator of the bot. If you'd like this integration to always send to
+the topic your topic, just add &topic=your%20topic to the end of the URL.
+

--- a/slack-zotero.py
+++ b/slack-zotero.py
@@ -36,9 +36,10 @@ def retrieve_articles(group_id, api_key, limit=1, include='data', since=0):
     zotero_url += "&since={0}".format(since) if since else ""
 
     print("Retrieving most recent {limit} articles since version: {version}".format(limit=limit, version=since))
+    print("URL: ",zotero_url)
 
     response = urllib.request.urlopen(zotero_url)
-    articles = json.loads(response.readall().decode('utf-8'))
+    articles = json.loads(response.read().decode('utf-8'))
 
     print("Retrieved {0} articles".format(len(articles)))
 
@@ -48,8 +49,14 @@ def retrieve_articles(group_id, api_key, limit=1, include='data', since=0):
 def send_article_to_slack(webhook_url, article, channel=None, username=None, icon_emoji=None, verbose=True, mock=False):
     """Sends a JSON article to the given Slack Webhooks URL"""
     payload = {"text": format_article(article)}
+
     if channel:
         payload['channel'] = channel
+    else:
+        # kinda hard-wired by Jarv for Zulip. 
+        # channel in Zulip is the title of the thread, so we pull the title of
+        # the paper out of the Zotero data structure & use that
+        payload['channel'] = article['data']['title'] 
 
     if username:
         payload['username'] = username

--- a/zulip-zotero.sh
+++ b/zulip-zotero.sh
@@ -1,0 +1,11 @@
+# --group and --api refer to Zotero
+# The rest of the options are for the Slack-webhook (or Slack-compatible Zulip-webhook)
+python3 slack-zotero.py --group 1966 \
+                            --api "SECRET_^_^_KEY" \
+    --webhook "https://frost.zulipchat.com/api/v1/external/slack_incoming?api_key=ALSO_SECRET_^_^_KEY&stream=zotero" \
+                            --since 0 \
+                            --username "Zotero Bot" \
+                            --icon ":book:" \
+                            --artifact "slack-zotero-bot-previous.json" \
+                            -v
+


### PR DESCRIPTION
- Fixed a small bug (readall() -> read())
- added a useful default for Zulip integration (the 'channel' (thread subject) defaults to the paper title)
- added a lot more details to the README